### PR TITLE
Feature/landscape

### DIFF
--- a/Merchant.xcodeproj/project.pbxproj
+++ b/Merchant.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		C4DD67192417FE9200C72768 /* AgreementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DD67182417FE9200C72768 /* AgreementViewController.swift */; };
 		C4DD671B241828E100C72768 /* UITapGestureRecognizer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DD671A241828E100C72768 /* UITapGestureRecognizer+Extensions.swift */; };
 		C4DD671D241829E900C72768 /* NSAttributedString+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DD671C241829E900C72768 /* NSAttributedString+Extensions.swift */; };
+		D6FC3FC7283EB75A00647147 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FC3FC6283EB75A00647147 /* UIViewController.swift */; };
 		E5C8A04A9E7571A1C836CA74 /* Pods_Merchant_MerchantUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F03BE384B9233089BDF8F6C /* Pods_Merchant_MerchantUITests.framework */; };
 /* End PBXBuildFile section */
 
@@ -269,6 +270,7 @@
 		C4DD671A241828E100C72768 /* UITapGestureRecognizer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITapGestureRecognizer+Extensions.swift"; sourceTree = "<group>"; };
 		C4DD671C241829E900C72768 /* NSAttributedString+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Extensions.swift"; sourceTree = "<group>"; };
 		CB816F5C7C102071EE166A68 /* Pods_Merchant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Merchant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6FC3FC6283EB75A00647147 /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		DCF5732E0852906CF836DCA7 /* Pods-Merchant-MerchantUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Merchant-MerchantUITests.debug.xcconfig"; path = "Target Support Files/Pods-Merchant-MerchantUITests/Pods-Merchant-MerchantUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		E46EB0020643631F3A27E827 /* Pods-MerchantTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MerchantTests.release.xcconfig"; path = "Target Support Files/Pods-MerchantTests/Pods-MerchantTests.release.xcconfig"; sourceTree = "<group>"; };
 		FAAA19CAA1F377C630BDE3D7 /* Pods_MerchantTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MerchantTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -604,6 +606,7 @@
 		C4AF25B823FEB50F0050AD41 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				D6FC3FC3283EA22F00647147 /* Extensions */,
 				C4AF25B623FEB4430050AD41 /* Application Delegate */,
 				C4AF25C123FEBA5A0050AD41 /* Resources */,
 				C4AF25B923FEB5820050AD41 /* Localization */,
@@ -656,6 +659,14 @@
 				C4DD67182417FE9200C72768 /* AgreementViewController.swift */,
 			);
 			path = Agreement;
+			sourceTree = "<group>";
+		};
+		D6FC3FC3283EA22F00647147 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				D6FC3FC6283EB75A00647147 /* UIViewController.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -938,6 +949,7 @@
 				C441ABD1240927FC00A2253A /* WebSocket.swift in Sources */,
 				C433DB9D2424D85C00570C2C /* CFTimeInterval+Extensions.swift in Sources */,
 				C49E1CB724227688009B2020 /* URL+Helpers.swift in Sources */,
+				D6FC3FC7283EB75A00647147 /* UIViewController.swift in Sources */,
 				C445559424010C7400F4B3E0 /* TransactionTableViewCell.swift in Sources */,
 				C445558E24007F0700F4B3E0 /* Date+Extensions.swift in Sources */,
 				C445559C24016ECB00F4B3E0 /* ItemsView.swift in Sources */,

--- a/Merchant/Extensions/UIViewController.swift
+++ b/Merchant/Extensions/UIViewController.swift
@@ -1,0 +1,27 @@
+//
+//  UIViewController.swift
+//  Merchant
+//
+//  Created by Eliot Lesar on 5/25/22.
+//  Copyright © 2022 Bitcoin.com. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIViewController {
+     internal var windowInterfaceOrientation: UIInterfaceOrientation? {
+        if #available(iOS 13.0, *) {
+            return UIApplication.shared.windows.first?.windowScene?.interfaceOrientation
+        } else {
+            // Fallback on earlier versions
+            return UIApplication.shared.statusBarOrientation
+        }
+    }
+    
+    internal func valueForOrientation<T>(portraitValue: T, landscapeValue: T, defaultValue: T? = nil) -> T {
+        guard let windowInterfaceOrientation = self.windowInterfaceOrientation else { return defaultValue ?? portraitValue }
+        
+        return windowInterfaceOrientation.isPortrait ? portraitValue : landscapeValue
+    }
+}

--- a/Merchant/Info.plist
+++ b/Merchant/Info.plist
@@ -49,6 +49,13 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 </dict>

--- a/Merchant/Utilities/AppConstants.swift
+++ b/Merchant/Utilities/AppConstants.swift
@@ -11,7 +11,8 @@ import UIKit
 
 struct AppConstants {
     static let ANIMATION_DURATION = 0.3
-    static let SIDE_MENU_OFFSET: CGFloat = 100.0
+    static let SIDE_MENU_OFFSET_PORTRAIT: CGFloat = 100.0
+    static let SIDE_MENU_OFFSET_LANDSCAPE: CGFloat = 480.0
     static let GENERAL_MARGIN: CGFloat = 35.0
     static let GENERAL_CORNER_RADIUS: CGFloat = 20.0
     static let PIN_NUMBERS_REQUIRED = 4

--- a/Merchant/View Controllers/Container/ContainerViewController.swift
+++ b/Merchant/View Controllers/Container/ContainerViewController.swift
@@ -36,6 +36,14 @@ final class ContainerViewController: UIViewController {
         }
     }
     
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        coordinator.animate(alongsideTransition: { [self] (context) in
+            hideSideMenu()
+        })
+    }
+    
     // MARK: - Actions
     @objc private func showSideMenu() {
         guard !isMenuOpened else {
@@ -47,8 +55,9 @@ final class ContainerViewController: UIViewController {
         
         isMenuOpened = true
         
+        let sideMenuOffset : CGFloat = valueForOrientation(portraitValue: AppConstants.SIDE_MENU_OFFSET_PORTRAIT, landscapeValue: AppConstants.SIDE_MENU_OFFSET_LANDSCAPE)
         var sideMenuFrame = sideMenuViewController.view.frame
-        sideMenuFrame.origin.x = -AppConstants.SIDE_MENU_OFFSET
+        sideMenuFrame.origin.x = -sideMenuOffset
         
         UIView.animate(withDuration: AppConstants.ANIMATION_DURATION) {
             self.sideMenuViewController.view.frame = sideMenuFrame
@@ -174,7 +183,6 @@ final class ContainerViewController: UIViewController {
             viewController.view.frame.origin.y = UIScreen.main.bounds.size.height
         }
     }
-
 }
 
 extension ContainerViewController: PinViewControllerDelegate {
@@ -193,5 +201,4 @@ extension ContainerViewController: PinViewControllerDelegate {
     func pinViewControllerDidClose(_ viewController: PinViewController) {
         closePinViewController(viewController)
     }
-    
 }

--- a/Merchant/View Controllers/Payment Input/PaymentInputViewController.swift
+++ b/Merchant/View Controllers/Payment Input/PaymentInputViewController.swift
@@ -34,6 +34,9 @@ final class PaymentInputViewController: UIViewController {
         return formatter
     }
     
+    // MARK: - Layout Properties
+    private var constraints : [NSLayoutConstraint] = [];
+    
     // MARK: - View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -59,6 +62,14 @@ final class PaymentInputViewController: UIViewController {
         super.viewDidDisappear(animated)
         
         amountString = "0"
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        coordinator.animate(alongsideTransition: { [self] (context) in
+            setupConstraints()
+        })
     }
     
     // MARK: - Public API
@@ -115,6 +126,7 @@ final class PaymentInputViewController: UIViewController {
         setupOverlayButton()
         setupMenuButton()
         registerForNotifications()
+        setupConstraints()
     }
     
     private func setupKeypadView() {
@@ -124,17 +136,6 @@ final class PaymentInputViewController: UIViewController {
         keypadView.backgroundColor = .white
         keypadView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(keypadView)
-        var screenWidth = UIScreen.main.bounds.size.width
-        var keypadMargin = Constants.KEYPAD_VIEW_MARGIN
-        if(screenWidth >= 600) {
-            keypadMargin = 164.0
-        }
-        NSLayoutConstraint.activate([
-            keypadView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: keypadMargin),
-            keypadView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -keypadMargin),
-            keypadView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: Constants.KEYPAD_VIEW_CENTER_OFFSET),
-            keypadView.heightAnchor.constraint(equalToConstant: 4 * Constants.KEYPAD_BUTTON_SIZE)
-        ])
     }
     
     private func setupCheckoutButton() {
@@ -145,12 +146,6 @@ final class PaymentInputViewController: UIViewController {
         checkoutButton.layer.cornerRadius = Constants.CHECKOUT_BUTTON_HEIGHT / 2
         checkoutButton.addTarget(self, action: #selector(checkoutButtonTapped), for: .touchUpInside)
         view.addSubview(checkoutButton)
-        NSLayoutConstraint.activate([
-            checkoutButton.leadingAnchor.constraint(equalTo: keypadView.leadingAnchor),
-            checkoutButton.trailingAnchor.constraint(equalTo: keypadView.trailingAnchor),
-            checkoutButton.topAnchor.constraint(equalTo: keypadView.bottomAnchor, constant: AppConstants.GENERAL_MARGIN),
-            checkoutButton.heightAnchor.constraint(equalToConstant: Constants.CHECKOUT_BUTTON_HEIGHT)
-        ])
     }
     
     private func setupEnterAmountLabel() {
@@ -158,10 +153,6 @@ final class PaymentInputViewController: UIViewController {
         enterAmountLabel.translatesAutoresizingMaskIntoConstraints = false
         enterAmountLabel.font = .systemFont(ofSize: 16.0)
         view.addSubview(enterAmountLabel)
-        NSLayoutConstraint.activate([
-            enterAmountLabel.centerXAnchor.constraint(equalTo: keypadView.centerXAnchor),
-            enterAmountLabel.bottomAnchor.constraint(equalTo: keypadView.topAnchor, constant: -Constants.ENTER_AMOUNT_LABEL_BOTTOM_MARGIN)
-        ])
     }
     
     private func setupLabelsStackView() {
@@ -180,10 +171,6 @@ final class PaymentInputViewController: UIViewController {
         labelsStackView.spacing = Constants.LABELS_STACK_VIEW_SPACING
         labelsStackView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(labelsStackView)
-        NSLayoutConstraint.activate([
-            labelsStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            labelsStackView.bottomAnchor.constraint(equalTo: enterAmountLabel.topAnchor, constant: -Constants.LABELS_STACK_VIEW_BOTTOM_MARGIN)
-        ])
     }
     
     private func setupMenuButton() {
@@ -193,12 +180,6 @@ final class PaymentInputViewController: UIViewController {
         menuButton.addTarget(self, action: #selector(menuButtonTapped), for: .touchUpInside)
         menuButton.tintColor = .black
         view.addSubview(menuButton)
-        NSLayoutConstraint.activate([
-            menuButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.MENU_BUTTON_MARGIN),
-            menuButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constants.MENU_BUTTON_MARGIN / 2),
-            menuButton.heightAnchor.constraint(equalToConstant: Constants.MENU_BUTTON_SIZE),
-            menuButton.widthAnchor.constraint(equalToConstant: Constants.MENU_BUTTON_SIZE)
-        ])
     }
     
     private func setupOverlayButton() {
@@ -207,12 +188,62 @@ final class PaymentInputViewController: UIViewController {
         overlayButton.translatesAutoresizingMaskIntoConstraints = false
         overlayButton.addTarget(self, action: #selector(menuButtonTapped), for: .touchUpInside)
         view.addSubview(overlayButton)
-        NSLayoutConstraint.activate([
+    }
+    
+    
+    private func setupConstraints() {
+        NSLayoutConstraint.deactivate(constraints)
+        
+        constraints = [
+            checkoutButton.leadingAnchor.constraint(equalTo: keypadView.leadingAnchor),
+            checkoutButton.trailingAnchor.constraint(equalTo: keypadView.trailingAnchor),
+            checkoutButton.topAnchor.constraint(equalTo: keypadView.bottomAnchor, constant: AppConstants.GENERAL_MARGIN),
+            checkoutButton.heightAnchor.constraint(equalToConstant: Constants.CHECKOUT_BUTTON_HEIGHT),
+            
+            enterAmountLabel.centerXAnchor.constraint(equalTo: keypadView.centerXAnchor),
+            enterAmountLabel.bottomAnchor.constraint(equalTo: keypadView.topAnchor, constant: -Constants.ENTER_AMOUNT_LABEL_BOTTOM_MARGIN),
+            
+            labelsStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            labelsStackView.bottomAnchor.constraint(equalTo: enterAmountLabel.topAnchor, constant: -Constants.LABELS_STACK_VIEW_BOTTOM_MARGIN),
+            
+            menuButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.MENU_BUTTON_MARGIN),
+            menuButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constants.MENU_BUTTON_MARGIN / 2),
+            menuButton.heightAnchor.constraint(equalToConstant: Constants.MENU_BUTTON_SIZE),
+            menuButton.widthAnchor.constraint(equalToConstant: Constants.MENU_BUTTON_SIZE),
+            
             overlayButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             overlayButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             overlayButton.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            overlayButton.topAnchor.constraint(equalTo: view.topAnchor)
+            overlayButton.topAnchor.constraint(equalTo: view.topAnchor),
+        ]
+        
+        let screenWidth = UIScreen.main.bounds.size.width
+        let screenHeight = UIScreen.main.bounds.size.height
+        let keypadButtonSize : CGFloat
+        let keypadViewCenterOffset : CGFloat
+        
+        var keypadMargin = Constants.KEYPAD_VIEW_MARGIN
+        if(screenWidth >= 600) {
+            keypadMargin = 164.0
+        }
+        
+        if windowInterfaceOrientation?.isLandscape ?? false {
+            keypadMargin = 256.0
+            keypadButtonSize = screenHeight / 5 * 3
+            keypadViewCenterOffset = Constants.KEYPAD_VIEW_CENTER_OFFSET_LANDSCAPE
+        } else {
+            keypadButtonSize = screenWidth / 5 * 4
+            keypadViewCenterOffset = Constants.KEYPAD_VIEW_CENTER_OFFSET_PORTRAIT
+        }
+        
+        constraints.append(contentsOf: [
+            keypadView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: keypadMargin),
+            keypadView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -keypadMargin),
+            keypadView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: keypadViewCenterOffset),
+            keypadView.heightAnchor.constraint(equalToConstant: keypadButtonSize)
         ])
+        
+        NSLayoutConstraint.activate(constraints)
     }
     
     private func localize() {
@@ -306,7 +337,7 @@ private struct Constants {
     static let MENU_BUTTON_MARGIN: CGFloat = 20.0
     static let OVERLAY_BUTTON_VISIBLE_ALPHA: CGFloat = 0.7
     static let MAX_ALLOWED_NUMBER_OF_DIGITS = 12
-    static let KEYPAD_VIEW_CENTER_OFFSET: CGFloat = 50.0
+    static let KEYPAD_VIEW_CENTER_OFFSET_PORTRAIT: CGFloat = 50.0
+    static let KEYPAD_VIEW_CENTER_OFFSET_LANDSCAPE: CGFloat = 32.0
     static let KEYPAD_VIEW_MARGIN: CGFloat = 35.0
-    static let KEYPAD_BUTTON_SIZE: CGFloat = UIScreen.main.bounds.size.width / 5
 }

--- a/Merchant/View Controllers/Settings/SettingsViewController.swift
+++ b/Merchant/View Controllers/Settings/SettingsViewController.swift
@@ -22,7 +22,10 @@ final class SettingsViewController: UIViewController {
   private var walletLabel = UILabel()
   private var localBitcoinCashAdView = UIView()
   private var localBitcoinCashLabel = UILabel()
-  private var itemsViewHeightConstraint: NSLayoutConstraint?
+    
+    // MARK: - Layout Properties
+    private var itemsViewHeightConstraint: NSLayoutConstraint?
+    private var constraints : [NSLayoutConstraint] = [];
 
   // MARK: - View Lifecycle
   override func viewDidLoad() {
@@ -32,6 +35,14 @@ final class SettingsViewController: UIViewController {
     localize()
     registerForNotifications()
   }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        coordinator.animate(alongsideTransition: { [self] (context) in
+            setupConstraints()
+        })
+    }
 
   // MARK: - Actions
   @objc private func walletAdViewTapped() {
@@ -60,6 +71,7 @@ final class SettingsViewController: UIViewController {
     setupItemsView()
     setupWalletAdView()
     setupLocalBitcoinCashAdView()
+    setupConstraints()
     updateScrollViewContentSize()
 
     view.bringSubviewToFront(topOverlayView)
@@ -69,12 +81,6 @@ final class SettingsViewController: UIViewController {
   private func setupTopOverlayView() {
     topOverlayView.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(topOverlayView)
-    NSLayoutConstraint.activate([
-      topOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-      topOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      topOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
-      topOverlayView.heightAnchor.constraint(equalToConstant: Constants.TOP_OVERLAY_VIEW_HEIGHT),
-    ])
   }
 
   private func setupNavigationBar() {
@@ -88,12 +94,6 @@ final class SettingsViewController: UIViewController {
       }
     }
     view.addSubview(navigationBar)
-    NSLayoutConstraint.activate([
-      navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-      navigationBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-      navigationBar.heightAnchor.constraint(equalToConstant: NavigationBar.height),
-    ])
   }
 
   private func setupScrollView() {
@@ -101,12 +101,6 @@ final class SettingsViewController: UIViewController {
     scrollView.showsVerticalScrollIndicator = false
     scrollView.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(scrollView)
-    NSLayoutConstraint.activate([
-      scrollView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-      scrollView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor),
-      scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-      scrollView.widthAnchor.constraint(equalToConstant: Constants.SCROLL_VIEW_WIDTH),
-    ])
   }
 
   private func setupItemsView() {
@@ -121,15 +115,6 @@ final class SettingsViewController: UIViewController {
     itemsView.delegate = self
     itemsView.translatesAutoresizingMaskIntoConstraints = false
     scrollView.addSubview(itemsView)
-
-    itemsViewHeightConstraint = itemsView.heightAnchor.constraint(equalToConstant: itemsView.height)
-
-    NSLayoutConstraint.activate([
-      itemsView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
-      itemsView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
-      itemsView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-      itemsViewHeightConstraint!,
-    ])
   }
 
   private func setupWalletAdView() {
@@ -137,15 +122,6 @@ final class SettingsViewController: UIViewController {
     walletAdView.translatesAutoresizingMaskIntoConstraints = false
     walletAdView.isUserInteractionEnabled = true
     scrollView.addSubview(walletAdView)
-    NSLayoutConstraint.activate([
-      walletAdView.leadingAnchor.constraint(
-        equalTo: itemsView.leadingAnchor, constant: Constants.AD_HORIZONTAL_PADDING),
-      walletAdView.trailingAnchor.constraint(
-        equalTo: itemsView.trailingAnchor, constant: -Constants.AD_HORIZONTAL_PADDING),
-      walletAdView.topAnchor.constraint(
-        equalTo: itemsView.bottomAnchor, constant: Constants.AD_TOP_MARGIN),
-      walletAdView.heightAnchor.constraint(equalToConstant: Constants.AD_HEIGHT),
-    ])
 
     // Tap Gesture.
     let tapGestureRecognizer = UITapGestureRecognizer(
@@ -190,15 +166,6 @@ final class SettingsViewController: UIViewController {
     walletLabel.adjustsFontSizeToFitWidth = true
     walletLabel.translatesAutoresizingMaskIntoConstraints = false
     walletAdView.addSubview(walletLabel)
-    NSLayoutConstraint.activate([
-      walletLabel.leadingAnchor.constraint(
-        equalTo: walletAdView.leadingAnchor, constant: Constants.LOGO_LEADING_MARGIN),
-      walletLabel.topAnchor.constraint(
-        equalTo: walletAdView.topAnchor, constant: Constants.LABEL_TOP_MARGIN),
-      walletLabel.bottomAnchor.constraint(
-        equalTo: walletAdView.bottomAnchor, constant: -Constants.LOGO_TOP_MARGIN),
-      walletLabel.widthAnchor.constraint(equalToConstant: Constants.LABEL_WIDTH),
-    ])
   }
 
   private func setupLocalBitcoinCashAdView() {
@@ -206,15 +173,6 @@ final class SettingsViewController: UIViewController {
     localBitcoinCashAdView.translatesAutoresizingMaskIntoConstraints = false
     localBitcoinCashAdView.isUserInteractionEnabled = true
     scrollView.addSubview(localBitcoinCashAdView)
-    NSLayoutConstraint.activate([
-      localBitcoinCashAdView.leadingAnchor.constraint(
-        equalTo: itemsView.leadingAnchor, constant: Constants.AD_HORIZONTAL_PADDING),
-      localBitcoinCashAdView.trailingAnchor.constraint(
-        equalTo: itemsView.trailingAnchor, constant: -Constants.AD_HORIZONTAL_PADDING),
-      localBitcoinCashAdView.topAnchor.constraint(
-        equalTo: walletAdView.bottomAnchor, constant: Constants.AD_TOP_MARGIN),
-      localBitcoinCashAdView.heightAnchor.constraint(equalToConstant: Constants.AD_HEIGHT),
-    ])
 
     // Tap Gesture.
     let tapGestureRecognizer = UITapGestureRecognizer(
@@ -259,16 +217,73 @@ final class SettingsViewController: UIViewController {
     localBitcoinCashLabel.adjustsFontSizeToFitWidth = true
     localBitcoinCashLabel.translatesAutoresizingMaskIntoConstraints = false
     localBitcoinCashAdView.addSubview(localBitcoinCashLabel)
-    NSLayoutConstraint.activate([
-      localBitcoinCashLabel.leadingAnchor.constraint(
-        equalTo: localBitcoinCashAdView.leadingAnchor, constant: Constants.LOGO_LEADING_MARGIN),
-      localBitcoinCashLabel.topAnchor.constraint(
-        equalTo: localBitcoinCashAdView.topAnchor, constant: Constants.LABEL_TOP_MARGIN),
-      localBitcoinCashLabel.bottomAnchor.constraint(
-        equalTo: localBitcoinCashAdView.bottomAnchor, constant: -Constants.LOGO_TOP_MARGIN),
-      localBitcoinCashLabel.widthAnchor.constraint(equalToConstant: Constants.LABEL_WIDTH),
-    ])
   }
+    
+    private func setupConstraints() {
+        NSLayoutConstraint.deactivate(constraints)
+        
+        let labelWidth = UIScreen.main.bounds.size.width / 2 - Constants.LOGO_LEADING_MARGIN - Constants.ITEMS_VIEW_MARGIN
+        let scrollViewWidth = UIScreen.main.bounds.size.width - 2 * AppConstants.GENERAL_MARGIN
+        
+        constraints = [
+            topOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
+            topOverlayView.heightAnchor.constraint(equalToConstant: Constants.TOP_OVERLAY_VIEW_HEIGHT),
+            
+            navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationBar.heightAnchor.constraint(equalToConstant: NavigationBar.height),
+            
+            scrollView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            scrollView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            scrollView.widthAnchor.constraint(equalToConstant: scrollViewWidth),
+            
+            itemsView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            itemsView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
+            itemsView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            
+            walletAdView.leadingAnchor.constraint(
+              equalTo: itemsView.leadingAnchor, constant: Constants.AD_HORIZONTAL_PADDING),
+            walletAdView.trailingAnchor.constraint(
+              equalTo: itemsView.trailingAnchor, constant: -Constants.AD_HORIZONTAL_PADDING),
+            walletAdView.topAnchor.constraint(
+              equalTo: itemsView.bottomAnchor, constant: Constants.AD_TOP_MARGIN),
+            walletAdView.heightAnchor.constraint(equalToConstant: Constants.AD_HEIGHT),
+            
+            walletLabel.leadingAnchor.constraint(
+              equalTo: walletAdView.leadingAnchor, constant: Constants.LOGO_LEADING_MARGIN),
+            walletLabel.topAnchor.constraint(
+              equalTo: walletAdView.topAnchor, constant: Constants.LABEL_TOP_MARGIN),
+            walletLabel.bottomAnchor.constraint(
+              equalTo: walletAdView.bottomAnchor, constant: -Constants.LOGO_TOP_MARGIN),
+            walletLabel.widthAnchor.constraint(equalToConstant: labelWidth),
+        
+            localBitcoinCashAdView.leadingAnchor.constraint(
+              equalTo: itemsView.leadingAnchor, constant: Constants.AD_HORIZONTAL_PADDING),
+            localBitcoinCashAdView.trailingAnchor.constraint(
+              equalTo: itemsView.trailingAnchor, constant: -Constants.AD_HORIZONTAL_PADDING),
+            localBitcoinCashAdView.topAnchor.constraint(
+              equalTo: walletAdView.bottomAnchor, constant: Constants.AD_TOP_MARGIN),
+            localBitcoinCashAdView.heightAnchor.constraint(equalToConstant: Constants.AD_HEIGHT),
+            
+            localBitcoinCashLabel.leadingAnchor.constraint(
+              equalTo: localBitcoinCashAdView.leadingAnchor, constant: Constants.LOGO_LEADING_MARGIN),
+            localBitcoinCashLabel.topAnchor.constraint(
+              equalTo: localBitcoinCashAdView.topAnchor, constant: Constants.LABEL_TOP_MARGIN),
+            localBitcoinCashLabel.bottomAnchor.constraint(
+              equalTo: localBitcoinCashAdView.bottomAnchor, constant: -Constants.LOGO_TOP_MARGIN),
+            localBitcoinCashLabel.widthAnchor.constraint(equalToConstant: Constants.LABEL_WIDTH)
+        ]
+        
+        itemsViewHeightConstraint = itemsView.heightAnchor.constraint(equalToConstant: itemsView.height)
+        
+        constraints.append(itemsViewHeightConstraint!)
+        
+        NSLayoutConstraint.activate(constraints)
+    }
 
   private func updateScrollViewContentSize() {
     var height = itemsView.height

--- a/Merchant/View Controllers/Side Menu/SideMenuViewController.swift
+++ b/Merchant/View Controllers/Side Menu/SideMenuViewController.swift
@@ -23,11 +23,32 @@ final class SideMenuViewController: UIViewController {
         MenuItem.about
     ]
     
+    // MARK: - Layout Properties
+    private var orientationConstraints : [NSLayoutConstraint] = [];
+    
     // MARK: - View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
         setupView()
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        coordinator.animate(alongsideTransition: { [self] (context) in
+            NSLayoutConstraint.deactivate(orientationConstraints)
+            
+            let sideMenuOffset : CGFloat = valueForOrientation(portraitValue: AppConstants.SIDE_MENU_OFFSET_PORTRAIT, landscapeValue: AppConstants.SIDE_MENU_OFFSET_LANDSCAPE)
+            orientationConstraints = [
+                tableView.topAnchor.constraint(equalTo: view.topAnchor),
+                tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: sideMenuOffset)
+            ]
+            
+            NSLayoutConstraint.activate(orientationConstraints)
+        })
     }
     
     // MARK: - Private API
@@ -48,12 +69,16 @@ final class SideMenuViewController: UIViewController {
         tableView.separatorColor = .clear
         tableView.contentInsetAdjustmentBehavior = .never
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
+        
+        let sideMenuOffset : CGFloat = valueForOrientation(portraitValue: AppConstants.SIDE_MENU_OFFSET_PORTRAIT, landscapeValue: AppConstants.SIDE_MENU_OFFSET_LANDSCAPE)
+        orientationConstraints = [
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppConstants.SIDE_MENU_OFFSET)
-        ])
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: sideMenuOffset)
+        ]
+        
+        NSLayoutConstraint.activate(orientationConstraints)
         
         setupTableHeader()
         tableView.reloadData()


### PR DESCRIPTION
Enabled landscape orientation for iPad devices. iPhone is still locked to portrait orientation.

Views and constraints are still set up programmatically. Views that were not behaving correctly during orientation changes now have their constraints consolidated into a helper function that is called every time the screen orientation changes. This helper function deactivates the existing constraints and then reactivates a new set of constraints with any orientation-related changes that are needed.