### PR TITLE
Re-enabled xpub functionality.

### DIFF
--- a/Merchant.xcodeproj/project.pbxproj
+++ b/Merchant.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		C4DD67192417FE9200C72768 /* AgreementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DD67182417FE9200C72768 /* AgreementViewController.swift */; };
 		C4DD671B241828E100C72768 /* UITapGestureRecognizer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DD671A241828E100C72768 /* UITapGestureRecognizer+Extensions.swift */; };
 		C4DD671D241829E900C72768 /* NSAttributedString+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DD671C241829E900C72768 /* NSAttributedString+Extensions.swift */; };
+		D6A2995C28760B0C00F6028B /* ReadOnlyHDWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A2995B28760B0C00F6028B /* ReadOnlyHDWallet.swift */; };
 		D6FC3FC7283EB75A00647147 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FC3FC6283EB75A00647147 /* UIViewController.swift */; };
 		E5C8A04A9E7571A1C836CA74 /* Pods_Merchant_MerchantUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F03BE384B9233089BDF8F6C /* Pods_Merchant_MerchantUITests.framework */; };
 /* End PBXBuildFile section */
@@ -270,6 +271,7 @@
 		C4DD671A241828E100C72768 /* UITapGestureRecognizer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITapGestureRecognizer+Extensions.swift"; sourceTree = "<group>"; };
 		C4DD671C241829E900C72768 /* NSAttributedString+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Extensions.swift"; sourceTree = "<group>"; };
 		CB816F5C7C102071EE166A68 /* Pods_Merchant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Merchant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6A2995B28760B0C00F6028B /* ReadOnlyHDWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyHDWallet.swift; sourceTree = "<group>"; };
 		D6FC3FC6283EB75A00647147 /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		DCF5732E0852906CF836DCA7 /* Pods-Merchant-MerchantUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Merchant-MerchantUITests.debug.xcconfig"; path = "Target Support Files/Pods-Merchant-MerchantUITests/Pods-Merchant-MerchantUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		E46EB0020643631F3A27E827 /* Pods-MerchantTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MerchantTests.release.xcconfig"; path = "Target Support Files/Pods-MerchantTests/Pods-MerchantTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -460,6 +462,7 @@
 				4DF0D5822467A796007E1B3D /* RateManager.swift */,
 				4DFC75C12467AA2400C8D6BF /* RateNetwork.swift */,
 				4D23422C2467AB8C001382F4 /* RateInteractor.swift */,
+				D6A2995B28760B0C00F6028B /* ReadOnlyHDWallet.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -949,6 +952,7 @@
 				C441ABD1240927FC00A2253A /* WebSocket.swift in Sources */,
 				C433DB9D2424D85C00570C2C /* CFTimeInterval+Extensions.swift in Sources */,
 				C49E1CB724227688009B2020 /* URL+Helpers.swift in Sources */,
+				D6A2995C28760B0C00F6028B /* ReadOnlyHDWallet.swift in Sources */,
 				D6FC3FC7283EB75A00647147 /* UIViewController.swift in Sources */,
 				C445559424010C7400F4B3E0 /* TransactionTableViewCell.swift in Sources */,
 				C445558E24007F0700F4B3E0 /* Date+Extensions.swift in Sources */,

--- a/Merchant/Custom Views/ItemsView/ItemsView.swift
+++ b/Merchant/Custom Views/ItemsView/ItemsView.swift
@@ -139,7 +139,7 @@ extension ItemsView: UITableViewDataSource, UITableViewDelegate {
 }
 
 private struct Constants {
-    static let XPUB_DESTINATION_CELL_HEIGHT: CGFloat = 100.0
+    static let XPUB_DESTINATION_CELL_HEIGHT: CGFloat = 120.0
     static let DESTINATION_CELL_HEIGHT: CGFloat = 80.0
     static let CELL_HEIGHT: CGFloat = 65.0
 }

--- a/Merchant/Custom Views/ItemsView/ItemsView.swift
+++ b/Merchant/Custom Views/ItemsView/ItemsView.swift
@@ -139,7 +139,7 @@ extension ItemsView: UITableViewDataSource, UITableViewDelegate {
 }
 
 private struct Constants {
-    static let XPUB_DESTINATION_CELL_HEIGHT: CGFloat = 120.0
     static let DESTINATION_CELL_HEIGHT: CGFloat = 80.0
+    static let XPUB_DESTINATION_CELL_HEIGHT: CGFloat = UIDevice.current.userInterfaceIdiom == .phone ? 120.0 : DESTINATION_CELL_HEIGHT
     static let CELL_HEIGHT: CGFloat = 65.0
 }

--- a/Merchant/Custom Views/ItemsView/ItemsView.swift
+++ b/Merchant/Custom Views/ItemsView/ItemsView.swift
@@ -88,7 +88,13 @@ final class ItemsView: CardView {
     
     private func calculateHeight() -> CGFloat {
         var height =  CGFloat(items.count - 1) * Constants.CELL_HEIGHT
-        height += Constants.DESTINATION_CELL_HEIGHT
+        
+        if let paymentTarget = UserManager.shared.activePaymentTarget, paymentTarget.type == .xPub {
+            height += Constants.XPUB_DESTINATION_CELL_HEIGHT
+        } else {
+            height += Constants.DESTINATION_CELL_HEIGHT
+        }
+        
         return height
     }
     
@@ -120,6 +126,10 @@ extension ItemsView: UITableViewDataSource, UITableViewDelegate {
         let item = items[indexPath.row]
         
         if item.title == UserItem.destinationAddress.title {
+            if let paymentTarget = UserManager.shared.activePaymentTarget, paymentTarget.type == .xPub {
+                return Constants.XPUB_DESTINATION_CELL_HEIGHT
+            }
+            
             return Constants.DESTINATION_CELL_HEIGHT
         }
         

--- a/Merchant/Localization/en.lproj/Localizable.strings
+++ b/Merchant/Localization/en.lproj/Localizable.strings
@@ -72,7 +72,7 @@
 
 "no_history_text" = "There is no transaction history.";
 
-"options_explain_payment_address" = "A destination address is a Bitcoin Cash address";
+"options_explain_payment_address" = "A destination address can either be a Bitcoin Cash address, or an Extended Public Key (xpub) or a merchant API key or pairing code";
 
 "options_add_payment_address" = "Add destination address";
 

--- a/Merchant/Localization/nl.lproj/Localizable.strings
+++ b/Merchant/Localization/nl.lproj/Localizable.strings
@@ -72,7 +72,7 @@
 
 "no_history_text" = "There is no transaction history.";
 
-"options_explain_payment_address" = "A destination address is a Bitcoin Cash address";
+"options_explain_payment_address" = "A destination address can either be a Bitcoin Cash address, or an Extended Public Key (xpub) or a merchant API key or pairing code";
 
 "options_add_payment_address" = "Add destination address";
 

--- a/Merchant/Localization/pt-PT.lproj/Localizable.strings
+++ b/Merchant/Localization/pt-PT.lproj/Localizable.strings
@@ -72,7 +72,7 @@
 
 "no_history_text" = "There is no transaction history.";
 
-"options_explain_payment_address" = "A destination address is a Bitcoin Cash address";
+"options_explain_payment_address" = "A destination address can either be a Bitcoin Cash address, or an Extended Public Key (xpub) or a merchant API key or pairing code";
 
 "options_add_payment_address" = "Add destination address";
 

--- a/Merchant/Localization/th.lproj/Localizable.strings
+++ b/Merchant/Localization/th.lproj/Localizable.strings
@@ -72,7 +72,7 @@
 
 "no_history_text" = "There is no transaction history.";
 
-"options_explain_payment_address" = "A destination address is a Bitcoin Cash address";
+"options_explain_payment_address" = "A destination address can either be a Bitcoin Cash address, or an Extended Public Key (xpub) or a merchant API key or pairing code";
 
 "options_add_payment_address" = "Add destination address";
 

--- a/Merchant/Models/PaymentTarget.swift
+++ b/Merchant/Models/PaymentTarget.swift
@@ -37,7 +37,10 @@ final class PaymentTarget: Codable {
         return legacyAddress
     }
     var invoiceRequestAddress: String? {
-        if type == .address {
+        if type == .xPub {
+            return WalletManager.shared.generateAddressFromStoredIndex()
+        }
+        else if type == .address {
             return target
         }
         
@@ -56,6 +59,11 @@ final class PaymentTarget: Codable {
     // MARK: - Private API
     private func setup() {
         type = .invalid
+        
+        if isXPub() {
+            type = .xPub
+            return
+        }
         
         if isLegacyAddress() {
             type = .address

--- a/Merchant/Utilities/ReadOnlyHDWallet.swift
+++ b/Merchant/Utilities/ReadOnlyHDWallet.swift
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 Horizontal Systems <hsdao@protonmail.ch>
+// Derived from https://github.com/horizontalsystems/hd-wallet-kit-ios/blob/master/HdWalletKit/Classes/ReadOnlyHDWallet.swift
+// Copyright (c) 2022 Software Verde, LLC <value@softwareverde.com>
+
+import OpenSslKit
+import BitcoinKit
+
+public class ReadOnlyHDWallet {
+
+    enum ParseError: Error {
+        case InvalidExtendedPublicKey
+        case InvalidChecksum
+    }
+
+    private static func dataTo<T>(data: Data, type: T.Type) -> T {
+        data.withUnsafeBytes { $0.load(as: T.self) }
+    }
+
+    private static func publicKeys(raw: Data, chainCode: Data, xPubKey: UInt32, depth: UInt8, fingerprint: UInt32, childIndex: UInt32, indices: Range<UInt32>, chain: HDWallet.Chain) throws -> [PublicKey] {
+        guard let firstIndex = indices.first, let lastIndex = indices.last else {
+            return []
+        }
+
+        if (0x80000000 & firstIndex) != 0 && (0x80000000 & lastIndex) != 0 {
+            throw DerivationError.derivationFailed
+        }
+
+        var hdKey = HDKey(privateKey: nil, publicKey: raw, chainCode: chainCode, depth: depth, fingerprint: fingerprint, childIndex: childIndex)
+
+        guard let derivedHdKey = Kit.derivedHDKey(hdKey: hdKey, at: UInt32(chain.rawValue), hardened: false), let publicKey = derivedHdKey.publicKey else {
+            throw DerivationError.derivationFailed
+        }
+
+        hdKey = HDKey(privateKey: nil, publicKey: publicKey, chainCode: derivedHdKey.chainCode, depth: derivedHdKey.depth, fingerprint: derivedHdKey.fingerprint, childIndex: derivedHdKey.childIndex)
+
+        var keys = [PublicKey]()
+
+        for i in indices {
+            guard let key = Kit.derivedHDKey(hdKey: hdKey, at: i, hardened: false), let publicKey = key.publicKey else {
+                throw DerivationError.derivationFailed
+            }
+
+            keys.append(PublicKey(bytes: publicKey, network: .mainnetBCH))
+        }
+
+        return keys
+    }
+
+    public static func publicKeys(extendedPublicKey: String, indices: Range<UInt32>, chain: HDWallet.Chain) throws -> [PublicKey] {
+        let data = OpenSslKit.Base58.decode(extendedPublicKey)
+
+        guard data.count == 82 else {
+            throw ParseError.InvalidExtendedPublicKey
+        }
+
+        let xPubKey = dataTo(data: Data(data[0..<4].reversed()), type: UInt32.self)
+        let depth = dataTo(data: Data(data[4..<5]), type: UInt8.self)
+        let fingerprint = dataTo(data: Data(data[5..<9]), type: UInt32.self)
+        let childIndex = dataTo(data: Data(data[9..<13]), type: UInt32.self)
+        let chainCode = Data(data[13..<45])
+        let key = Data(data[45..<78])
+        let checksum = Data(data[78..<82])
+
+        guard checksum == Kit.sha256sha256(data.prefix(78)).prefix(4) else {
+            throw ParseError.InvalidChecksum
+        }
+
+        return try Self.publicKeys(raw: key, chainCode: chainCode, xPubKey: xPubKey, depth: depth, fingerprint: fingerprint, childIndex: childIndex, indices: indices, chain: chain)
+    }
+}

--- a/Merchant/Utilities/WalletManager.swift
+++ b/Merchant/Utilities/WalletManager.swift
@@ -13,11 +13,77 @@ final class WalletManager {
 
     // MARK: - Properties
     static let shared = WalletManager()
-    private var wallet: HDWallet?
-    private var index = 0 {
-        didSet {
-            UserManager.shared.xPubKeyIndex = index
+    
+    // MARK: - Public API
+    func syncXPub(with address: String) {
+        guard let data = address.data(using: .utf8) else { return }
+        
+        let key = PublicKey(bytes: data, network: .mainnetBCH)
+        let address = key.toBitcoinAddress()
+        
+        doesAddressHaveHistoryOnBlockchain(address.cashaddr)
+    }
+    
+    func generateAddressFromStoredIndex() -> String? {
+        return generateNewAddress()
+    }
+
+    // MARK: - Private API
+    
+    // FIXME: This functionality currently requests information from a deprecated API, but fails silently.
+    private func doesAddressHaveHistoryOnBlockchain(_ address: String) {
+        guard let data = address.data(using: .utf8) else { return }
+
+        let key = PublicKey(bytes: data, network: .mainnetBCH)
+        let address = key.toBitcoinAddress()
+
+        if let url = URL(string: "\(Endpoints.addressDetails)/\(address.cashaddr)") {
+            do {
+                let data = try Data(contentsOf: url)
+
+                do {
+                    let addressDetails = try JSONDecoder().decode(AddressDetails.self, from: data)
+                    Logger.log(message: "Transactions: \(addressDetails.transactions.count)", type: .debug)
+
+                    if addressDetails.transactions.count > 0,
+                        let address = generateNewAddress(shouldIncrementIndex: true) {
+                        doesAddressHaveHistoryOnBlockchain(address)
+                    }
+                } catch {
+                    Logger.log(message: "Unable to parse: \(error.localizedDescription) | \(error)", type: .error)
+                    AnalyticsService.shared.logEvent(.error_syncing_xpub, withError: error)
+                }
+            } catch {
+                AnalyticsService.shared.logEvent(.error_rest_bitcoin_com_scan_address_funds, withError: error)
+            }
         }
     }
     
+    private func generateNewAddress(shouldIncrementIndex: Bool = false) -> String? {
+        guard let paymentTarget = UserManager.shared.activePaymentTarget else { return nil }
+        let xpub = paymentTarget.legacyAddress
+        let index = UserManager.shared.xPubKeyIndex
+        let indices = 0..<UInt32(index + 1)
+        
+        do {
+            Logger.log(message: "Generating Bitcoin Address for xPubKey index: \(index)", type: .info)
+            
+            let publicKeys = try ReadOnlyHDWallet.publicKeys(extendedPublicKey: xpub, indices: indices, chain: .external)
+            guard let publicKey = publicKeys.last else {
+                Logger.log(message: "Unable to retrieve newest public key for xPubKey index: \(index)", type: .info)
+                return nil
+            }
+            
+            if shouldIncrementIndex {
+                UserManager.shared.xPubKeyIndex += 1
+            }
+        
+            return publicKey.toBitcoinAddress().cashaddr
+        }
+        catch {
+            Logger.log(message: "Unable to generate Bitcoin Address for xPubKey index \(index): \(error.localizedDescription) | \(error)", type: .error)
+            AnalyticsService.shared.logEvent(.error_generate_address_from_xpub, withError: error)
+            return nil
+        }
+    }
 }

--- a/Merchant/View Controllers/Payment Request/PaymentRequestViewController.swift
+++ b/Merchant/View Controllers/Payment Request/PaymentRequestViewController.swift
@@ -598,12 +598,22 @@ final class PaymentRequestViewController: UIViewController {
         
         AnalyticsService.shared.logEvent(.invoice_paid)
         
+        // Increase the next index for xPubKey.
+        if let paymentTarget = UserManager.shared.activePaymentTarget, paymentTarget.type == .xPub {
+            UserManager.shared.xPubKeyIndex += 1
+        }
+        
         UIView.animate(withDuration: AppConstants.ANIMATION_DURATION) {
             self.paymentCompletedView.alpha = 1.0
         }
     }
     
     private func showBip21PaymentCompletedView() {
+        // Increase the next index for xPubKey.
+        if let paymentTarget = UserManager.shared.activePaymentTarget, paymentTarget.type == .xPub {
+            UserManager.shared.xPubKeyIndex += 1
+        }
+        
         UIView.animate(withDuration: AppConstants.ANIMATION_DURATION) {
             self.paymentCompletedView.alpha = 1.0
         }

--- a/Merchant/View Controllers/Settings/SettingsViewController.swift
+++ b/Merchant/View Controllers/Settings/SettingsViewController.swift
@@ -371,8 +371,9 @@ final class SettingsViewController: UIViewController {
 
       if let address = UIPasteboard.general.string {
         Logger.log(message: "Pasted BCH address: \(address)", type: .info)
-
-        self.validateAndStoreAddress(address)
+          let paymentTarget : PaymentTarget = PaymentTarget(target: address, type: .invalid)
+          
+        self.validateAndStoreAddress(paymentTarget)
       } else {
         self.showFailureMessage()
       }
@@ -382,9 +383,7 @@ final class SettingsViewController: UIViewController {
     present(alertController, animated: true)
   }
 
-  private func validateAndStoreAddress(_ address: String) {
-    let paymentTarget = PaymentTarget(target: address, type: .address)
-
+  private func validateAndStoreAddress(_ paymentTarget: PaymentTarget) {
     if paymentTarget.type == .invalid {
       showFailureMessage()
     } else {
@@ -578,7 +577,9 @@ extension SettingsViewController: ScannerViewControllerDelegate {
 
       Logger.log(message: "Scanned BCH address: \(stringValue)", type: .info)
 
-      self.validateAndStoreAddress(stringValue)
+        let paymentTarget : PaymentTarget = PaymentTarget(target: stringValue, type: .invalid)
+        
+      self.validateAndStoreAddress(paymentTarget)
     }
   }
 

--- a/Merchant/View Controllers/Settings/SettingsViewController.swift
+++ b/Merchant/View Controllers/Settings/SettingsViewController.swift
@@ -392,9 +392,25 @@ final class SettingsViewController: UIViewController {
 
       UserManager.shared.destination = paymentTarget.legacyAddress
       UserManager.shared.activePaymentTarget = paymentTarget
-      refreshAndShowSuccessMessage()
+      
+        if paymentTarget.type == .xPub {
+            refreshItemsView()
+            updateScrollViewContentSize()
+            syncXPub(paymentTarget.legacyAddress)
+        } else {
+            refreshAndShowSuccessMessage()
+        }
     }
   }
+    
+    private func syncXPub(_ address: String) {
+            ToastManager.shared.showMessage(Localized.syncingXPub, forStatus: .success)
+
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2.0) {
+                WalletManager.shared.syncXPub(with: address)
+                ToastManager.shared.showMessage(Localized.syncedXPub, forStatus: .success)
+            }
+        }
 
   private func createPin() {
     let pinViewController = PinViewController()
@@ -476,6 +492,8 @@ final class SettingsViewController: UIViewController {
     AnalyticsService.shared.logEvent(.settings_paymenttarget_changed)
 
     switch paymentTarget.type {
+    case .xPub:
+        AnalyticsService.shared.logEvent(.settings_paymenttarget_xpub_set)
     case .address:
       AnalyticsService.shared.logEvent(.settings_paymenttarget_pubkey_set)
     default:

--- a/MerchantTests/AddressTests.swift
+++ b/MerchantTests/AddressTests.swift
@@ -56,4 +56,47 @@ class AddressTests: XCTestCase {
         
         XCTAssertTrue(target.type == .address, "P2SH should be valid")
     }
+    
+    func testIsValidXPubKey() {
+        let xPubKeys = [
+            "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+            "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+            "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ",
+            "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
+            "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV",
+            "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy",
+            "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB",
+            "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH",
+            "xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a",
+            "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon",
+            "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL",
+            "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt",
+            "xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13",
+            "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y",
+            "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz",
+            "xpub6AHA9hZDN11k2ijHMeS5QqHx2KP9aMBRhTDqANMnwVtdyw2TDYRmF8PjpvwUFcL1Et8Hj59S3gTSMcUQ5gAqTz3Wd8EsMTmF3DChhqPQBnU",
+            "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+            " xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8 "
+        ]
+        
+        xPubKeys.forEach {
+            let target = PaymentTarget(target: $0, type: .xPub)
+            
+            XCTAssertTrue(target.type == .xPub, "xPubKey should be valid")
+        }
+    }
+    
+    func testExtractAddressFromExtendedPublicKey() {
+        let xPubKey = "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz"
+        
+        if let data = xPubKey.data(using: .utf8) {
+            let key = PublicKey(bytes: data, network: .mainnetBCH)
+            let address = key.toBitcoinAddress()
+            
+            XCTAssertNotNil(address.cashaddr.count > 0)
+        } else {
+            XCTFail("Data not extracted")
+        }
+    }
+    
 }

--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,7 @@ target 'Merchant' do
   # Pods for Merchant
   pod 'RealmSwift'
   pod 'BitcoinKit', :git => 'https://github.com/saltyskip/BitcoinKit.git'
+  pod 'OpenSslKit.swift'
   pod 'Amplitude-iOS'
   pod 'RxSwift',          '~> 5'
   pod 'RxCocoa',          '~> 5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,6 +7,7 @@ PODS:
   - Moya/RxSwift (14.0.0):
     - Moya/Core
     - RxSwift (~> 5.0)
+  - OpenSslKit.swift (1.2.2)
   - Realm (4.3.2):
     - Realm/Headers (= 4.3.2)
   - Realm/Headers (4.3.2)
@@ -23,6 +24,7 @@ DEPENDENCIES:
   - Amplitude-iOS
   - BitcoinKit (from `https://github.com/saltyskip/BitcoinKit.git`)
   - Moya/RxSwift (~> 14.0.0)
+  - OpenSslKit.swift
   - RealmSwift
   - RxCocoa (~> 5)
   - RxSwift (~> 5)
@@ -32,6 +34,7 @@ SPEC REPOS:
     - Alamofire
     - Amplitude-iOS
     - Moya
+    - OpenSslKit.swift
     - Realm
     - RealmSwift
     - RxCocoa
@@ -52,12 +55,13 @@ SPEC CHECKSUMS:
   Amplitude-iOS: 7d8cdc3408ba35c2e68368fc7c692cd104606b94
   BitcoinKit: a8c198d2a57caf64dc43271901f8c5a2309aced2
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
+  OpenSslKit.swift: 0e2194853fd9ce42006cf18c89743331406a10a9
   Realm: 5e92902e2875dff4bb0fd02f67bb737c3d5db2bc
   RealmSwift: 9a360fc7bae04fc2e308a34fbd899d5faa2d6b22
   RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
   RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
   RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
 
-PODFILE CHECKSUM: ff614967e3967dc78a806eb613b7ab31d106c2ed
+PODFILE CHECKSUM: 9583a955194bf6ed61814e7ddccdd26013e80f7f
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
- Reverted commit 5e8cbe832677c992dbe6c75f443b51fa7450a607
- WalletManager's reliance on HDWallet was replaced with a modified version of ReadOnlyHDWallet. This class was derived from Horizontal Systems' HdWalletKit (https://github.com/horizontalsystems/hd-wallet-kit-ios/blob/master/HdWalletKit/Classes/ReadOnlyHDWallet.swift)
- ReadOnlyHDWallet derives additional public keys based on the merchant's original xpub key, whereas the original HDWallet implementation generated a new address by creating a new private key and keychain to handle key derivation.
- xpub indexing is now handled exclusively by UserManager 